### PR TITLE
Regtest genesis

### DIFF
--- a/console/executor.cpp
+++ b/console/executor.cpp
@@ -118,7 +118,16 @@ bool executor::do_initchain() {
         LOG_INFO(LOG_NODE) << format(BN_INITIALIZING_CHAIN) % directory;
 
         bool const testnet = libbitcoin::get_network(metadata_.configured.network.identifier) == libbitcoin::config::settings::testnet;
-        auto const genesis = testnet ? block::genesis_testnet() : block::genesis_mainnet();
+
+        bool const testnet_blocks = metadata_.configured.chain.easy_blocks;
+        bool const retarget = metadata_.configured.chain.retarget;
+        const auto mainnet = retarget && !testnet_blocks;
+
+        auto genesis = testnet ? block::genesis_testnet() : block::genesis_mainnet();
+        if (!mainnet && !testnet_blocks) {
+            ////NOTE: To be on regtest, retarget and easy_blocks options must be set to false
+            genesis = block::genesis_regtest();
+        }
         auto const& settings = metadata_.configured.database;
         auto const result = data_base(settings).create(genesis);
 

--- a/console/executor.cpp
+++ b/console/executor.cpp
@@ -117,17 +117,8 @@ bool executor::do_initchain() {
     if (create_directories(directory, ec)) {
         LOG_INFO(LOG_NODE) << format(BN_INITIALIZING_CHAIN) % directory;
 
-        bool const testnet = libbitcoin::get_network(metadata_.configured.network.identifier) == libbitcoin::config::settings::testnet;
+        auto const genesis = libbitcoin::node::full_node::get_genesis_block(metadata_.configured.chain);
 
-        bool const testnet_blocks = metadata_.configured.chain.easy_blocks;
-        bool const retarget = metadata_.configured.chain.retarget;
-        const auto mainnet = retarget && !testnet_blocks;
-
-        auto genesis = testnet ? block::genesis_testnet() : block::genesis_mainnet();
-        if (!mainnet && !testnet_blocks) {
-            ////NOTE: To be on regtest, retarget and easy_blocks options must be set to false
-            genesis = block::genesis_regtest();
-        }
         auto const& settings = metadata_.configured.database;
         auto const result = data_base(settings).create(genesis);
 


### PR DESCRIPTION
The genesis block is needed because it has a low difficulty already set (that is going to be used during all the regtests tests). If the testnet genesis is used, the difficulty will be high and the testing slow